### PR TITLE
🎨 ランディングページのメインボタン文言変更

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,7 +35,7 @@ export default function HomePage() {
                   <Link href="/interview">
                     <Button size="lg" className="gap-2">
                       <FileText className="h-4 w-4" />
-                      インタビュー録をアップロード
+                      広告作成を始める
                       <ArrowRight className="h-4 w-4" />
                     </Button>
                   </Link>


### PR DESCRIPTION
## 📋 概要
ランディングページのメインCTAボタンの文言を「インタビュー録をアップロード」から「広告作成を始める」に変更してユーザビリティを向上させました。

## 🔧 変更内容
- `app/page.tsx` 38行目のボタンテキストを変更
- リンク先（`/interview`）は維持

Closes #12

Generated with [Claude Code](https://claude.ai/code)